### PR TITLE
Support ndim>1

### DIFF
--- a/src/pytorch/spe/spe.py
+++ b/src/pytorch/spe/spe.py
@@ -282,14 +282,14 @@ class ConvSPE(nn.Module):
         qbar = self.conv_k(z)
 
         # truncate to desired shape (remove the start to avoid the border effects)
+        indices = [slice(batchsize * num_realizations), slice(self.num_heads * self.in_features)]
         for dim in range(len(shape)):
             k = self.kernel_size[dim]
             s = original_shape[dim]
+            indices.append(slice(k, k + s, 1))
 
-            indices = [slice(batchsize*num_realizations),
-                       slice(self.num_heads*self.in_features)] + [slice(k, k+s, 1), ]
-            qbar = qbar[indices]
-            kbar = kbar[indices]
+        qbar = qbar[indices]
+        kbar = kbar[indices]
 
         # making (batchsize, num_realizations, num_heads, keys_dim, *shape)
         kbar = kbar.view(batchsize, num_realizations,


### PR DESCRIPTION
Hi there,

I tried to use ConvSPE with images (ndim=2) but spe.py failed.
The following snippet replicates the error with the current spe implementation. Notice, I am using a 2D (50x50) input.
This PR fixes this error. If this fix is wrong, please suggest a better solution.
Thanks
```
import spe
import torch

device = 'cuda' if torch.cuda.is_available() else 'cpu'

keys_dim = 64
num_heads = 1
num_realizations = 64
kernel_size = 20
n = 50
batchsize = 8

poscoder = spe.ConvSPE(ndim=2,in_features=keys_dim,kernel_size=kernel_size,num_heads=num_heads,num_realizations=num_realizations)
filter = spe.SPEFilter(gated=True, code_shape=poscoder.code_shape).to(device)

poscoder.to(device=device)

q = torch.rand(batchsize, n, n, num_heads, keys_dim, device=device, requires_grad=True)
k = torch.rand(batchsize, n, n, num_heads, keys_dim, device=device, requires_grad=True)


poscode = poscoder(q.shape[:3])
q, k = filter(q, k, poscode)
```